### PR TITLE
Updates for service-bus v6 and event-store v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_script:
   - mkdir -p "$HOME/.php-cs-fixer"
   - phpenv config-rm xdebug.ini
   - composer self-update
-  - composer update --prefer-dist $DEPENDENCIES
+  - composer update $DEPENDENCIES
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; else ./vendor/bin/phpunit; fi

--- a/composer.json
+++ b/composer.json
@@ -66,6 +66,11 @@
             "ProophTest\\EventStore\\": "vendor/prooph/event-store/tests/"
         }
     },
+    "config": {
+        "preferred-install": {
+            "prooph/*": "source"
+        }
+    },
     "scripts": {
         "check": [
             "@cs",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "container-interop/container-interop": "^1.1",
         "phpspec/prophecy": "^1.7",
         "prooph/php-cs-fixer-config": "^0.1.1",
-        "phpunit/phpunit": "^6",
+        "phpunit/phpunit": "^6.0",
         "prooph/event-store" : "^7.0-beta4",
         "react/promise": "^2.4.1",
         "sandrokeil/interop-config": "^2.0.1",
@@ -62,7 +62,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "ProophTest\\ServiceBus\\": "vendor/prooph/service-bus/tests/"
+            "ProophTest\\ServiceBus\\": "vendor/prooph/service-bus/tests/",
+            "ProophTest\\EventStore\\": "vendor/prooph/event-store/tests/"
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -27,18 +27,18 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "~7.0",
+        "php": "^7.1",
         "beberlei/assert": "^2.7.1",
         "prolic/humus-amqp": "^1.0",
-        "prooph/common" : "^4.0-dev",
-        "prooph/service-bus" : "^6.0-beta3"
+        "prooph/common" : "^4.0",
+        "prooph/service-bus" : "^6.0"
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",
-        "phpspec/prophecy": "dev-patch-1 as 1.6.2",
+        "phpspec/prophecy": "^1.7",
         "prooph/php-cs-fixer-config": "^0.1.1",
-        "phpunit/phpunit": "^5.7",
-        "prooph/event-store" : "^7.0-beta2",
+        "phpunit/phpunit": "^6",
+        "prooph/event-store" : "^7.0-beta4",
         "react/promise": "^2.4.1",
         "sandrokeil/interop-config": "^2.0.1",
         "satooshi/php-coveralls": "^1.0",
@@ -73,11 +73,5 @@
         "cs": "php-cs-fixer fix -v --diff --dry-run",
         "cs-fix": "php-cs-fixer fix -v --diff",
         "test": "phpunit"
-    },
-    "repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/prolic/prophecy.git"
-        }
-    ]
+    }
 }

--- a/docs/message_producer.md
+++ b/docs/message_producer.md
@@ -152,3 +152,23 @@ return [
     ],
 ];
 ```
+
+# Delayed Messages
+
+Delayed messages are messages that should be executed at a specific point in time.
+F.e. execute a command in 5min from now on.
+
+In order to make it really work, you need to configure a delayed message exchange and configure it accordingly.
+The RabbitMQ extension [delayed-message-exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) is required.
+
+A delayed message must implement `Prooph\ServiceBus\Message\HumusAmqp\DelayedMessage`.
+If you are using `Prooph\Common\Messaging\Command` as your base command class, you can simply use
+`Prooph\ServiceBus\Message\HumusAmqp\DelayedCommand` instead.
+
+## Usage
+
+```php
+$command = SomeCommand::withData(['foo' => 'bar'])->executeAt((new DateTimeImmutable('now'))->modify('+5 mins'));
+
+$commandBus->dispatch($command);
+```

--- a/docs/message_producer.md
+++ b/docs/message_producer.md
@@ -158,7 +158,7 @@ return [
 Delayed messages are messages that should be executed at a specific point in time.
 F.e. execute a command in 5min from now on.
 
-In order to make it really work, you need to configure a delayed message exchange and configure it accordingly.
+In order to make it work, you need to configure a delayed message exchange and configure it accordingly.
 The RabbitMQ extension [delayed-message-exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) is required.
 
 A delayed message must implement `Prooph\ServiceBus\Message\HumusAmqp\DelayedMessage`.
@@ -172,3 +172,4 @@ $command = SomeCommand::withData(['foo' => 'bar'])->executeAt((new DateTimeImmut
 
 $commandBus->dispatch($command);
 ```
+

--- a/src/AmqpQueryProducer.php
+++ b/src/AmqpQueryProducer.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Prooph\ServiceBus\Message\HumusAmqp;
 
-use Humus\Amqp\JsonRpc\Error;
 use Humus\Amqp\JsonRpc\JsonRpcClient;
 use Humus\Amqp\JsonRpc\JsonRpcRequest;
 use Prooph\Common\Messaging\Message;

--- a/src/AmqpQueryProducer.php
+++ b/src/AmqpQueryProducer.php
@@ -35,14 +35,31 @@ final class AmqpQueryProducer implements MessageProducer
     private $messageConverter;
 
     /**
+     * @var array
+     */
+    private $messageNameToServerNameMap;
+
+    /**
+     * @var string|null
+     */
+    private $defaultServerName;
+
+    /**
      * @var float
      */
     private $timeout;
 
-    public function __construct(JsonRpcClient $client, MessageConverter $messageConverter, float $timeout = 0.0)
-    {
+    public function __construct(
+        JsonRpcClient $client,
+        MessageConverter $messageConverter,
+        array $messageNameToServerNameMap,
+        string $defaultServerName = null,
+        float $timeout = 0.0
+    ) {
         $this->client = $client;
         $this->messageConverter = $messageConverter;
+        $this->messageNameToServerNameMap = $messageNameToServerNameMap;
+        $this->defaultServerName = $defaultServerName;
         $this->timeout = $timeout;
     }
 
@@ -68,7 +85,7 @@ final class AmqpQueryProducer implements MessageProducer
                 $data = $this->arrayFromMessage($parallelMessage);
 
                 $this->client->addRequest(new JsonRpcRequest(
-                    'server',
+                    $this->serverName($message->messageName()),
                     $message->messageName(),
                     $data,
                     $message->uuid()->toString(),
@@ -77,33 +94,37 @@ final class AmqpQueryProducer implements MessageProducer
                     $message->createdAt()->getTimestamp()
                 ));
             }
-        } else {
-            $data = $this->arrayFromMessage($message);
 
-            $messageId = $message->uuid()->toString();
+            $responseCollection = $this->client->getResponseCollection($this->timeout);
 
-            $this->client->addRequest(new JsonRpcRequest(
-                'server',
-                $message->messageName(),
-                $data,
-                $messageId,
-                $message->messageName(),
-                0,
-                $message->createdAt()->getTimestamp()
-            ));
+            $deferred->resolve($responseCollection);
 
-            $results = $this->client->getResponseCollection($this->timeout);
-
-            if ($results instanceof Error) {
-                $deferred->reject($results->message());
-            }
-
-            $response = $results->getResponse($messageId);
-
-            $deferred->resolve($response->result());
+            return;
         }
 
-        $deferred->resolve($this->client->getResponseCollection($this->timeout));
+        $data = $this->arrayFromMessage($message);
+
+        $messageId = $message->uuid()->toString();
+
+        $this->client->addRequest(new JsonRpcRequest(
+            $this->serverName($message->messageName()),
+            $message->messageName(),
+            $data,
+            $messageId,
+            $message->messageName(),
+            0,
+            $message->createdAt()->getTimestamp()
+        ));
+
+        $responseCollection = $this->client->getResponseCollection($this->timeout);
+
+        $response = $responseCollection->getResponse($messageId);
+
+        if ($response->isError()) {
+            $deferred->reject($response->error()->message());
+        }
+
+        $deferred->resolve($response->result());
     }
 
     private function arrayFromMessage(Message $message): array
@@ -115,5 +136,16 @@ final class AmqpQueryProducer implements MessageProducer
         $messageData['created_at'] = $message->createdAt()->format('Y-m-d\TH:i:s.u');
 
         return $messageData;
+    }
+
+    private function serverName(string $messageName): string
+    {
+        if (isset($this->messageNameToServerNameMap[$messageName])) {
+            return $this->messageNameToServerNameMap[$messageName];
+        } elseif (null !== $this->defaultServerName) {
+            return $this->defaultServerName;
+        }
+
+        throw new RuntimeException('No server found for ' . $messageName);
     }
 }

--- a/src/AmqpQueryProducer.php
+++ b/src/AmqpQueryProducer.php
@@ -85,13 +85,13 @@ final class AmqpQueryProducer implements MessageProducer
                 $data = $this->arrayFromMessage($parallelMessage);
 
                 $this->client->addRequest(new JsonRpcRequest(
-                    $this->serverName($message->messageName()),
-                    $message->messageName(),
+                    $this->serverName($parallelMessage->messageName()),
+                    $parallelMessage->messageName(),
                     $data,
-                    $message->uuid()->toString(),
-                    $message->messageName(),
+                    $parallelMessage->uuid()->toString(),
+                    $parallelMessage->messageName(),
                     0,
-                    $message->createdAt()->getTimestamp()
+                    $parallelMessage->createdAt()->getTimestamp()
                 ));
             }
 

--- a/src/TransactionalEventPublisher.php
+++ b/src/TransactionalEventPublisher.php
@@ -12,10 +12,12 @@ declare(strict_types=1);
 
 namespace Prooph\ServiceBus\Message\HumusAmqp;
 
+use ArrayIterator;
 use Humus\Amqp\Producer;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\EventStore\ActionEventEmitterEventStore;
 use Prooph\EventStore\Plugin\AbstractPlugin;
+use Prooph\EventStore\Stream;
 use Prooph\EventStore\TransactionalActionEventEmitterEventStore;
 use Prooph\ServiceBus\EventBus;
 
@@ -94,8 +96,16 @@ final class TransactionalEventPublisher extends AbstractPlugin
             $this->inTransaction = true;
 
             while ($actionEvent = array_shift($this->queuedActionEvents)) {
-                $fallback = new \ArrayIterator();
-                $recordedEvents = $actionEvent->getParam('recordedEvents', $fallback);
+                $fallback = new ArrayIterator();
+                $recordedEvents = $actionEvent->getParam('stream');
+
+                if ($recordedEvents instanceof Stream) {
+                    // stream was created
+                    $recordedEvents = $recordedEvents->streamEvents();
+                } else {
+                    // events were appended
+                    $recordedEvents = $actionEvent->getParam('streamEvents', $fallback);
+                }
 
                 if ($fallback !== $recordedEvents) {
                     $this->producer->startTransaction();

--- a/tests/AmqpCommandConsumerCallbackTest.php
+++ b/tests/AmqpCommandConsumerCallbackTest.php
@@ -28,7 +28,7 @@ class AmqpCommandConsumerCallbackTest extends TestCase
     /**
      * @test
      */
-    public function it_acks_message_when_all_good()
+    public function it_acks_message_when_all_good(): void
     {
         $time = (string) microtime(true);
         if (false === strpos($time, '.')) {
@@ -74,7 +74,7 @@ class AmqpCommandConsumerCallbackTest extends TestCase
     /**
      * @test
      */
-    public function it_rejects_message_when_created_at_missing()
+    public function it_rejects_message_when_created_at_missing(): void
     {
         $envelope = $this->prophesize(Envelope::class);
         $envelope
@@ -96,7 +96,7 @@ class AmqpCommandConsumerCallbackTest extends TestCase
     /**
      * @test
      */
-    public function it_rejects_message_when_invalid_created_at_given()
+    public function it_rejects_message_when_invalid_created_at_given(): void
     {
         $envelope = $this->prophesize(Envelope::class);
         $envelope
@@ -118,7 +118,7 @@ class AmqpCommandConsumerCallbackTest extends TestCase
     /**
      * @test
      */
-    public function it_rejects_message_when_exception_occurred()
+    public function it_rejects_message_when_exception_occurred(): void
     {
         $time = (string) microtime(true);
         if (false === strpos($time, '.')) {
@@ -164,7 +164,7 @@ class AmqpCommandConsumerCallbackTest extends TestCase
     /**
      * @test
      */
-    public function it_rejects_and_requeues_message_when_concurrency_exception_occured()
+    public function it_rejects_and_requeues_message_when_concurrency_exception_occured(): void
     {
         $time = (string) microtime(true);
         if (false === strpos($time, '.')) {

--- a/tests/AmqpCommandConsumerCallbackTest.php
+++ b/tests/AmqpCommandConsumerCallbackTest.php
@@ -15,7 +15,7 @@ namespace ProophTest\ServiceBus\Message\HumusAmqp;
 use Humus\Amqp\DeliveryResult;
 use Humus\Amqp\Envelope;
 use Humus\Amqp\Queue;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Command;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\EventStore\Exception\ConcurrencyException;

--- a/tests/AmqpDelayedMessageProducerTest.php
+++ b/tests/AmqpDelayedMessageProducerTest.php
@@ -14,7 +14,7 @@ namespace ProophTest\ServiceBus\Message\HumusAmqp;
 
 use Humus\Amqp\Constants;
 use Humus\Amqp\Producer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\ServiceBus\Message\HumusAmqp\AmqpDelayedMessageProducer;

--- a/tests/AmqpDelayedMessageProducerTest.php
+++ b/tests/AmqpDelayedMessageProducerTest.php
@@ -17,6 +17,7 @@ use Humus\Amqp\Producer;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\ServiceBus\Exception\RuntimeException;
 use Prooph\ServiceBus\Message\HumusAmqp\AmqpDelayedMessageProducer;
 use Prooph\ServiceBus\Message\HumusAmqp\DelayedMessage;
 use React\Promise\Deferred;
@@ -26,7 +27,7 @@ class AmqpDelayedMessageProducerTest extends TestCase
     /**
      * @test
      */
-    public function it_publishes_messages()
+    public function it_publishes_messages(): void
     {
         $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
@@ -78,9 +79,9 @@ class AmqpDelayedMessageProducerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_deferred_passed()
+    public function it_throws_exception_when_deferred_passed(): void
     {
-        $this->expectException(\Prooph\ServiceBus\Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Prooph\ServiceBus\Message\HumusAmqp\AmqpDelayedMessageProducer cannot handle query messages which require future responses.');
 
         $producer = $this->prophesize(Producer::class);
@@ -95,9 +96,9 @@ class AmqpDelayedMessageProducerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_no_delayed_message_passed()
+    public function it_throws_exception_when_no_delayed_message_passed(): void
     {
-        $this->expectException(\Prooph\ServiceBus\Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Message is not a delayed message (instance of Prooph\ServiceBus\Message\HumusAmqp\DelayedMessage)');
 
         $producer = $this->prophesize(Producer::class);

--- a/tests/AmqpEventConsumerCallbackTest.php
+++ b/tests/AmqpEventConsumerCallbackTest.php
@@ -28,7 +28,7 @@ class AmqpEventConsumerCallbackTest extends TestCase
     /**
      * @test
      */
-    public function it_acks_message_when_all_good()
+    public function it_acks_message_when_all_good(): void
     {
         $time = (string) microtime(true);
         if (false === strpos($time, '.')) {
@@ -74,7 +74,7 @@ class AmqpEventConsumerCallbackTest extends TestCase
     /**
      * @test
      */
-    public function it_rejects_message_when_created_at_missing()
+    public function it_rejects_message_when_created_at_missing(): void
     {
         $envelope = $this->prophesize(Envelope::class);
         $envelope
@@ -96,7 +96,7 @@ class AmqpEventConsumerCallbackTest extends TestCase
     /**
      * @test
      */
-    public function it_rejects_message_when_invalid_created_at_given()
+    public function it_rejects_message_when_invalid_created_at_given(): void
     {
         $envelope = $this->prophesize(Envelope::class);
         $envelope
@@ -118,7 +118,7 @@ class AmqpEventConsumerCallbackTest extends TestCase
     /**
      * @test
      */
-    public function it_rejects_message_when_exception_occurred()
+    public function it_rejects_message_when_exception_occurred(): void
     {
         $time = (string) microtime(true);
         if (false === strpos($time, '.')) {
@@ -164,7 +164,7 @@ class AmqpEventConsumerCallbackTest extends TestCase
     /**
      * @test
      */
-    public function it_rejects_and_requeues_message_when_concurrency_exception_occurred()
+    public function it_rejects_and_requeues_message_when_concurrency_exception_occurred(): void
     {
         $time = (string) microtime(true);
         if (false === strpos($time, '.')) {

--- a/tests/AmqpEventConsumerCallbackTest.php
+++ b/tests/AmqpEventConsumerCallbackTest.php
@@ -15,7 +15,7 @@ namespace ProophTest\ServiceBus\Message\HumusAmqp;
 use Humus\Amqp\DeliveryResult;
 use Humus\Amqp\Envelope;
 use Humus\Amqp\Queue;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\EventStore\Exception\ConcurrencyException;

--- a/tests/AmqpMessageProducerTest.php
+++ b/tests/AmqpMessageProducerTest.php
@@ -17,6 +17,7 @@ use Humus\Amqp\Producer;
 use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageConverter;
+use Prooph\ServiceBus\Exception\RuntimeException;
 use Prooph\ServiceBus\Message\HumusAmqp\AmqpMessageProducer;
 use React\Promise\Deferred;
 
@@ -25,7 +26,7 @@ class AmqpMessageProducerTest extends TestCase
     /**
      * @test
      */
-    public function it_publishes_messages()
+    public function it_publishes_messages(): void
     {
         $now = new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
@@ -69,9 +70,9 @@ class AmqpMessageProducerTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_deferred_passed()
+    public function it_throws_exception_when_deferred_passed(): void
     {
-        $this->expectException(\Prooph\ServiceBus\Exception\RuntimeException::class);
+        $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Prooph\ServiceBus\Message\HumusAmqp\AmqpMessageProducer cannot handle query messages which require future responses.');
 
         $producer = $this->prophesize(Producer::class);

--- a/tests/AmqpMessageProducerTest.php
+++ b/tests/AmqpMessageProducerTest.php
@@ -14,7 +14,7 @@ namespace ProophTest\ServiceBus\Message\HumusAmqp;
 
 use Humus\Amqp\Constants;
 use Humus\Amqp\Producer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\Message;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\ServiceBus\Message\HumusAmqp\AmqpMessageProducer;

--- a/tests/AmqpQueryProducerTest.php
+++ b/tests/AmqpQueryProducerTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * This file is part of the prooph/humus-amqp-producer.
+ * (c) 2016-2017 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2017 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\ServiceBus\Message\HumusAmqp;
+
+use Humus\Amqp\Connection;
+use Humus\Amqp\ConnectionOptions;
+use Humus\Amqp\Constants;
+use Humus\Amqp\Envelope;
+use Humus\Amqp\Exchange;
+use Humus\Amqp\JsonRpc\JsonRpcClient;
+use Humus\Amqp\JsonRpc\JsonRpcResponse;
+use Humus\Amqp\Producer;
+use Humus\Amqp\Queue;
+use PHPUnit\Framework\TestCase;
+use Prooph\Common\Messaging\Message;
+use Prooph\Common\Messaging\MessageConverter;
+use Prooph\Common\Messaging\NoOpMessageConverter;
+use Prooph\ServiceBus\Exception\RuntimeException;
+use Prooph\ServiceBus\Message\HumusAmqp\AmqpQueryProducer;
+use ProophTest\ServiceBus\Mock\FetchSomething;
+use Prophecy\Argument;
+use React\Promise\Deferred;
+
+class AmqpQueryProducerTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_queries(): void
+    {
+        $message = new FetchSomething(['foo' => 'bar']);
+
+        $response = ['some' => 'result'];
+
+        $result = [
+            'result' => $response,
+        ];
+
+        $envelope = $this->prophesize(Envelope::class);
+        $envelope->getHeader('jsonrpc')->willReturn(JsonRpcResponse::JSONRPC_VERSION)->shouldBeCalled();
+        $envelope->getContentEncoding()->willReturn('UTF-8')->shouldBeCalled();
+        $envelope->getContentType()->willReturn('application/json')->shouldBeCalled();
+        $envelope->getBody()->willReturn(json_encode($result))->shouldBeCalled();
+        $envelope->getCorrelationId()->willReturn($message->uuid()->toString());
+
+        $options = $this->prophesize(ConnectionOptions::class);
+        $options->getLogin()->willReturn('sasa')->shouldBeCalled();
+
+        $connection = $this->prophesize(Connection::class);
+        $connection->getOptions()->willReturn($options->reveal());
+
+        $queue = $this->prophesize(Queue::class);
+        $queue->getName()->willReturn('test-queue')->shouldBeCalled();
+        $queue->get(Constants::AMQP_AUTOACK)->willReturn($envelope->reveal())->shouldBeCalled();
+        $queue->getConnection()->willReturn($connection->reveal())->shouldBeCalled();
+
+        $exchange = $this->prophesize(Exchange::class);
+        $exchange->publish(Argument::any(), Argument::any(), Constants::AMQP_NOPARAM, Argument::any())->shouldBeCalled();
+
+        $client = new JsonRpcClient($queue->reveal(), ['test-server' => $exchange->reveal()]);
+
+        $producer = new AmqpQueryProducer($client, new NoOpMessageConverter(), [FetchSomething::class => 'test-server']);
+
+        $deferred = new Deferred();
+
+        $producer($message, $deferred);
+
+        $hit = false;
+
+        $promise = $deferred->promise();
+        $promise->then(function (array $res) use (&$response, &$hit): void {
+            $this->assertEquals($response, $res);
+            $hit = true;
+        });
+
+        $promise->otherwise(function () {
+            $this->fail('Promise rejected');
+        });
+
+        $this->assertTrue($hit);
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_json_rpc_errors(): void
+    {
+        $message = new FetchSomething(['foo' => 'bar']);
+
+        $envelope = $this->prophesize(Envelope::class);
+        $envelope->getHeader('jsonrpc')->willReturn(JsonRpcResponse::JSONRPC_VERSION)->shouldBeCalled();
+        $envelope->getContentEncoding()->willReturn('UTF-16')->shouldBeCalled();
+        $envelope->getCorrelationId()->willReturn($message->uuid()->toString());
+
+        $options = $this->prophesize(ConnectionOptions::class);
+        $options->getLogin()->willReturn('sasa')->shouldBeCalled();
+
+        $connection = $this->prophesize(Connection::class);
+        $connection->getOptions()->willReturn($options->reveal());
+
+        $queue = $this->prophesize(Queue::class);
+        $queue->getName()->willReturn('test-queue')->shouldBeCalled();
+        $queue->get(Constants::AMQP_AUTOACK)->willReturn($envelope->reveal())->shouldBeCalled();
+        $queue->getConnection()->willReturn($connection->reveal())->shouldBeCalled();
+
+        $exchange = $this->prophesize(Exchange::class);
+        $exchange->publish(Argument::any(), Argument::any(), Constants::AMQP_NOPARAM, Argument::any())->shouldBeCalled();
+
+        $client = new JsonRpcClient($queue->reveal(), ['test-server' => $exchange->reveal()]);
+
+        $producer = new AmqpQueryProducer($client, new NoOpMessageConverter(), [], 'test-server');
+
+        $deferred = new Deferred();
+
+        $producer($message, $deferred);
+
+        $hit = false;
+
+        $promise = $deferred->promise();
+        $promise->then(function (): void {
+            $this->fail('Result returned');
+        });
+
+        $promise->otherwise(function (string $error) use (&$hit): void {
+            $this->assertEquals('Invalid JSON-RPC response', $error);
+            $hit = true;
+        });
+
+        $this->assertTrue($hit);
+    }
+
+    /**
+     * @test
+     * @group by
+     */
+    public function it_throws_exception_when_no_suitable_server_found_for_message(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No server found for ProophTest\ServiceBus\Mock\FetchSomething');
+
+        $message = new FetchSomething(['foo' => 'bar']);
+
+        $queue = $this->prophesize(Queue::class);
+
+        $exchange = $this->prophesize(Exchange::class);
+
+        $client = new JsonRpcClient($queue->reveal(), ['test-server' => $exchange->reveal()]);
+
+        $producer = new AmqpQueryProducer($client, new NoOpMessageConverter(), []);
+
+        $deferred = new Deferred();
+
+        $producer($message, $deferred);
+    }
+
+    /**
+     * @test
+     */
+    public function it_queries_parallel_messages(): void
+    {
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_no_deferred_passed(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Deferred expected, null given');
+
+        $queue = $this->prophesize(Queue::class);
+        $exchange = $this->prophesize(Exchange::class);
+        $client = new JsonRpcClient($queue->reveal(), [$exchange->reveal()]);
+        $messageConverter = $this->prophesize(MessageConverter::class);
+        $message = $this->prophesize(Message::class);
+
+        $messageProducer = new AmqpQueryProducer($client, $messageConverter->reveal(), []);
+        $messageProducer($message->reveal());
+    }
+}

--- a/tests/ConfirmSelectEventPublisherTest.php
+++ b/tests/ConfirmSelectEventPublisherTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\ServiceBus\Message\HumusAmqp;
 
 use Humus\Amqp\Producer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\DefaultActionEvent;
 use Prooph\ServiceBus\EventBus;

--- a/tests/ConfirmSelectEventPublisherTest.php
+++ b/tests/ConfirmSelectEventPublisherTest.php
@@ -35,7 +35,7 @@ class ConfirmSelectEventPublisherTest extends TestCase
     /**
      * @test
      */
-    public function it_confirms_select_and_waits_for_confirm_on_event_store_commit_post()
+    public function it_confirms_select_and_waits_for_confirm_on_event_store_commit_post(): void
     {
         $actionEvent = $this->prophesize(ActionEvent::class);
         $iterator = new ArrayIterator(['foo', 'bar']);
@@ -58,7 +58,7 @@ class ConfirmSelectEventPublisherTest extends TestCase
     /**
      * @test
      */
-    public function it_confirms_select_one_action_event_after_the_other()
+    public function it_confirms_select_one_action_event_after_the_other(): void
     {
         $actionEvent = $this->prophesize(ActionEvent::class);
         $iterator = new ArrayIterator(['foo', 'bar']);
@@ -77,7 +77,7 @@ class ConfirmSelectEventPublisherTest extends TestCase
         $eventBusCalls = [];
 
         $eventRouter = new EventRouter();
-        $eventRouter->route('foo')->to(function ($event) use ($plugin, &$eventBusCalls) {
+        $eventRouter->route('foo')->to(function ($event) use ($plugin, &$eventBusCalls): void {
             $eventBusCalls[] = $event;
             $actionEvent = new DefaultActionEvent($event, null, [
                 'streamEvents' => new ArrayIterator(['baz', 'bam', 'bat']),
@@ -85,16 +85,16 @@ class ConfirmSelectEventPublisherTest extends TestCase
             $plugin->onEventStoreCommitPost($actionEvent);
         });
 
-        $eventRouter->route('bar')->to(function ($event) use (&$eventBusCalls) {
+        $eventRouter->route('bar')->to(function ($event) use (&$eventBusCalls): void {
             $eventBusCalls[] = $event;
         });
-        $eventRouter->route('baz')->to(function ($event) use (&$eventBusCalls) {
+        $eventRouter->route('baz')->to(function ($event) use (&$eventBusCalls): void {
             $eventBusCalls[] = $event;
         });
-        $eventRouter->route('bam')->to(function ($event) use (&$eventBusCalls) {
+        $eventRouter->route('bam')->to(function ($event) use (&$eventBusCalls): void {
             $eventBusCalls[] = $event;
         });
-        $eventRouter->route('bat')->to(function ($event) use (&$eventBusCalls) {
+        $eventRouter->route('bat')->to(function ($event) use (&$eventBusCalls): void {
             $eventBusCalls[] = $event;
         });
 
@@ -209,7 +209,7 @@ class ConfirmSelectEventPublisherTest extends TestCase
     /**
      * @test
      */
-    public function it_does_nothing_when_no_recorded_events()
+    public function it_does_nothing_when_no_recorded_events(): void
     {
         $actionEvent = new DefaultActionEvent('name');
 

--- a/tests/Container/AmqpCommandConsumerCallbackFactoryTest.php
+++ b/tests/Container/AmqpCommandConsumerCallbackFactoryTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\ServiceBus\Message\HumusAmqp\Container;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\ServiceBus\CommandBus;
 use Prooph\ServiceBus\Message\HumusAmqp\AmqpCommandConsumerCallback;

--- a/tests/Container/AmqpCommandConsumerCallbackFactoryTest.php
+++ b/tests/Container/AmqpCommandConsumerCallbackFactoryTest.php
@@ -24,7 +24,7 @@ class AmqpCommandConsumerCallbackFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_amqp_command_consumer_callback()
+    public function it_creates_amqp_command_consumer_callback(): void
     {
         $commandBus = $this->prophesize(CommandBus::class);
         $messageFactory = $this->prophesize(MessageFactory::class);
@@ -53,7 +53,7 @@ class AmqpCommandConsumerCallbackFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_no_container_passed_to_call_static()
+    public function it_throws_exception_when_no_container_passed_to_call_static(): void
     {
         $this->expectException(\Prooph\ServiceBus\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type ' . ContainerInterface::class);

--- a/tests/Container/AmqpDelayedMessageProducerFactoryTest.php
+++ b/tests/Container/AmqpDelayedMessageProducerFactoryTest.php
@@ -24,7 +24,7 @@ class AmqpDelayedMessageProducerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_amqpDelayed_message_producer()
+    public function it_creates_amqpDelayed_message_producer(): void
     {
         $producer = $this->prophesize(Producer::class);
         $messageConverter = $this->prophesize(MessageConverter::class);
@@ -54,7 +54,7 @@ class AmqpDelayedMessageProducerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_no_container_passed_to_call_static()
+    public function it_throws_exception_when_no_container_passed_to_call_static(): void
     {
         $this->expectException(\Prooph\ServiceBus\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type ' . ContainerInterface::class);

--- a/tests/Container/AmqpDelayedMessageProducerFactoryTest.php
+++ b/tests/Container/AmqpDelayedMessageProducerFactoryTest.php
@@ -14,7 +14,7 @@ namespace ProophTest\ServiceBus\Message\HumusAmqpDelayed\Container;
 
 use Humus\Amqp\Producer;
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\ServiceBus\Message\HumusAmqp\AmqpDelayedMessageProducer;
 use Prooph\ServiceBus\Message\HumusAmqp\Container\AmqpDelayedMessageProducerFactory;

--- a/tests/Container/AmqpEventConsumerCallbackFactoryTest.php
+++ b/tests/Container/AmqpEventConsumerCallbackFactoryTest.php
@@ -24,7 +24,7 @@ class AmqpEventConsumerCallbackFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_amqp_event_consumer_callback()
+    public function it_creates_amqp_event_consumer_callback(): void
     {
         $eventBus = $this->prophesize(EventBus::class);
         $messageFactory = $this->prophesize(MessageFactory::class);
@@ -53,7 +53,7 @@ class AmqpEventConsumerCallbackFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_no_container_passed_to_call_static()
+    public function it_throws_exception_when_no_container_passed_to_call_static(): void
     {
         $this->expectException(\Prooph\ServiceBus\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type ' . ContainerInterface::class);

--- a/tests/Container/AmqpEventConsumerCallbackFactoryTest.php
+++ b/tests/Container/AmqpEventConsumerCallbackFactoryTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\ServiceBus\Message\HumusAmqp\Container;
 
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\MessageFactory;
 use Prooph\ServiceBus\EventBus;
 use Prooph\ServiceBus\Message\HumusAmqp\AmqpEventConsumerCallback;

--- a/tests/Container/AmqpMessageProducerFactoryTest.php
+++ b/tests/Container/AmqpMessageProducerFactoryTest.php
@@ -14,7 +14,7 @@ namespace ProophTest\ServiceBus\Message\HumusAmqp\Container;
 
 use Humus\Amqp\Producer;
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\ServiceBus\Message\HumusAmqp\AmqpMessageProducer;
 use Prooph\ServiceBus\Message\HumusAmqp\Container\AmqpMessageProducerFactory;

--- a/tests/Container/AmqpMessageProducerFactoryTest.php
+++ b/tests/Container/AmqpMessageProducerFactoryTest.php
@@ -24,7 +24,7 @@ class AmqpMessageProducerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_amqp_message_producer()
+    public function it_creates_amqp_message_producer(): void
     {
         $producer = $this->prophesize(Producer::class);
         $messageConverter = $this->prophesize(MessageConverter::class);
@@ -54,7 +54,7 @@ class AmqpMessageProducerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_no_container_passed_to_call_static()
+    public function it_throws_exception_when_no_container_passed_to_call_static(): void
     {
         $this->expectException(\Prooph\ServiceBus\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type ' . ContainerInterface::class);

--- a/tests/Container/AmqpMessageProducerPluginFactoryTest.php
+++ b/tests/Container/AmqpMessageProducerPluginFactoryTest.php
@@ -25,7 +25,7 @@ class AmqpMessageProducerPluginFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_message_producer_plugin()
+    public function it_creates_message_producer_plugin(): void
     {
         $producer = $this->prophesize(MessageProducer::class);
 
@@ -40,7 +40,7 @@ class AmqpMessageProducerPluginFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_message_producer_plugin_via_callstatic()
+    public function it_creates_message_producer_plugin_via_callstatic(): void
     {
         $producer = $this->prophesize(MessageProducer::class);
 
@@ -55,11 +55,11 @@ class AmqpMessageProducerPluginFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_given_invalid_container_to_callstatic()
+    public function it_throws_exception_given_invalid_container_to_callstatic(): void
     {
         $this->expectException(InvalidArgumentException::class);
 
         $name = 'producer';
-        $plugin = AmqpMessageProducerPluginFactory::$name('invalid container');
+        AmqpMessageProducerPluginFactory::$name('invalid container');
     }
 }

--- a/tests/Container/AmqpMessageProducerPluginFactoryTest.php
+++ b/tests/Container/AmqpMessageProducerPluginFactoryTest.php
@@ -14,7 +14,7 @@ namespace ProophTest\ServiceBus\Message\HumusAmqpDelayed\Container;
 
 use Humus\Amqp\Producer;
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\ServiceBus\Async\MessageProducer;
 use Prooph\ServiceBus\Exception\InvalidArgumentException;
 use Prooph\ServiceBus\Message\HumusAmqp\Container\AmqpMessageProducerPluginFactory;

--- a/tests/Container/ConfirmSelectEventPublisherFactoryTest.php
+++ b/tests/Container/ConfirmSelectEventPublisherFactoryTest.php
@@ -14,7 +14,7 @@ namespace ProophTest\ServiceBus\Message\HumusAmqp\Container;
 
 use Humus\Amqp\Producer;
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\ServiceBus\EventBus;
 use Prooph\ServiceBus\Message\HumusAmqp\ConfirmSelectEventPublisher;
 use Prooph\ServiceBus\Message\HumusAmqp\Container\ConfirmSelectEventPublisherFactory;

--- a/tests/Container/ConfirmSelectEventPublisherFactoryTest.php
+++ b/tests/Container/ConfirmSelectEventPublisherFactoryTest.php
@@ -24,7 +24,7 @@ class ConfirmSelectEventPublisherFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_plugin()
+    public function it_creates_plugin(): void
     {
         $eventBus = $this->prophesize(EventBus::class);
 
@@ -66,7 +66,7 @@ class ConfirmSelectEventPublisherFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_plugin_via_call_static()
+    public function it_creates_plugin_via_call_static(): void
     {
         $eventBus = $this->prophesize(EventBus::class);
 
@@ -109,7 +109,7 @@ class ConfirmSelectEventPublisherFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_invalid_container_given()
+    public function it_throws_exception_when_invalid_container_given(): void
     {
         $this->expectException(\Prooph\ServiceBus\Exception\InvalidArgumentException::class);
 

--- a/tests/Container/TransactionalEventPublisherFactoryTest.php
+++ b/tests/Container/TransactionalEventPublisherFactoryTest.php
@@ -14,7 +14,7 @@ namespace ProophTest\ServiceBus\Message\HumusAmqp\Container;
 
 use Humus\Amqp\Producer;
 use Interop\Container\ContainerInterface;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\ServiceBus\EventBus;
 use Prooph\ServiceBus\Message\HumusAmqp\Container\TransactionalEventPublisherFactory;
 use Prooph\ServiceBus\Message\HumusAmqp\TransactionalEventPublisher;

--- a/tests/Container/TransactionalEventPublisherFactoryTest.php
+++ b/tests/Container/TransactionalEventPublisherFactoryTest.php
@@ -24,7 +24,7 @@ class TransactionalEventPublisherFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_plugin()
+    public function it_creates_plugin(): void
     {
         $eventBus = $this->prophesize(EventBus::class);
 
@@ -66,7 +66,7 @@ class TransactionalEventPublisherFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_plugin_via_call_static()
+    public function it_creates_plugin_via_call_static(): void
     {
         $eventBus = $this->prophesize(EventBus::class);
 
@@ -109,7 +109,7 @@ class TransactionalEventPublisherFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_invalid_container_given()
+    public function it_throws_exception_when_invalid_container_given(): void
     {
         $this->expectException(\Prooph\ServiceBus\Exception\InvalidArgumentException::class);
 

--- a/tests/DelayedCommandTest.php
+++ b/tests/DelayedCommandTest.php
@@ -20,7 +20,7 @@ class DelayedCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_converts_from_and_to_array()
+    public function it_converts_from_and_to_array(): void
     {
         $time = (string) microtime(true);
         if (false === strpos($time, '.')) {
@@ -50,7 +50,7 @@ class DelayedCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_can_call_execute_at()
+    public function it_can_call_execute_at(): void
     {
         $command = $this->delayedComamnd();
         $later = $command->createdAt()->modify('+5 seconds');
@@ -59,10 +59,7 @@ class DelayedCommandTest extends TestCase
         $this->assertEquals(5000, $command->delay());
     }
 
-    /**
-     * @return DelayedCommand
-     */
-    private function delayedComamnd()
+    private function delayedComamnd(): DelayedCommand
     {
         return new class() extends DelayedCommand {
             protected $messageName = 'test-delayed-command';

--- a/tests/DelayedCommandTest.php
+++ b/tests/DelayedCommandTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 
 namespace ProophTest\ServiceBus\Message\HumusAmqp;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\ServiceBus\Message\HumusAmqp\DelayedCommand;
 
 class DelayedCommandTest extends TestCase

--- a/tests/TransactionalEventPublisherTest.php
+++ b/tests/TransactionalEventPublisherTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 namespace ProophTest\ServiceBus\Message\HumusAmqp;
 
 use Humus\Amqp\Producer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Prooph\Common\Event\ActionEvent;
 use Prooph\Common\Event\DefaultActionEvent;
 use Prooph\ServiceBus\EventBus;

--- a/tests/TransactionalEventPublisherTest.php
+++ b/tests/TransactionalEventPublisherTest.php
@@ -35,7 +35,7 @@ class TransactionalEventPublisherTest extends TestCase
     /**
      * @test
      */
-    public function it_starts_transactions_and_commits_on_event_store_commit_post()
+    public function it_starts_transactions_and_commits_on_event_store_commit_post(): void
     {
         $actionEvent = $this->prophesize(ActionEvent::class);
         $iterator = new \ArrayIterator(['foo', 'bar']);
@@ -57,7 +57,7 @@ class TransactionalEventPublisherTest extends TestCase
     /**
      * @test
      */
-    public function it_confirms_select_one_action_event_after_the_other()
+    public function it_confirms_select_one_action_event_after_the_other(): void
     {
         $actionEvent = $this->prophesize(ActionEvent::class);
         $iterator = new \ArrayIterator(['foo', 'bar']);
@@ -75,7 +75,7 @@ class TransactionalEventPublisherTest extends TestCase
         $eventBusCalls = [];
 
         $eventRouter = new EventRouter();
-        $eventRouter->route('foo')->to(function ($event) use ($plugin, &$eventBusCalls) {
+        $eventRouter->route('foo')->to(function ($event) use ($plugin, &$eventBusCalls): void {
             $eventBusCalls[] = $event;
             $actionEvent = new DefaultActionEvent($event, null, [
                 'streamEvents' => new \ArrayIterator(['baz', 'bam', 'bat']),
@@ -83,16 +83,16 @@ class TransactionalEventPublisherTest extends TestCase
             $plugin->onEventStoreCommitPost($actionEvent);
         });
 
-        $eventRouter->route('bar')->to(function ($event) use (&$eventBusCalls) {
+        $eventRouter->route('bar')->to(function ($event) use (&$eventBusCalls): void {
             $eventBusCalls[] = $event;
         });
-        $eventRouter->route('baz')->to(function ($event) use (&$eventBusCalls) {
+        $eventRouter->route('baz')->to(function ($event) use (&$eventBusCalls): void {
             $eventBusCalls[] = $event;
         });
-        $eventRouter->route('bam')->to(function ($event) use (&$eventBusCalls) {
+        $eventRouter->route('bam')->to(function ($event) use (&$eventBusCalls): void {
             $eventBusCalls[] = $event;
         });
-        $eventRouter->route('bat')->to(function ($event) use (&$eventBusCalls) {
+        $eventRouter->route('bat')->to(function ($event) use (&$eventBusCalls): void {
             $eventBusCalls[] = $event;
         });
 
@@ -204,7 +204,7 @@ class TransactionalEventPublisherTest extends TestCase
     /**
      * @test
      */
-    public function it_does_nothing_when_no_recorded_events()
+    public function it_does_nothing_when_no_recorded_events(): void
     {
         $actionEvent = new DefaultActionEvent('name');
 


### PR DESCRIPTION
resolves https://github.com/prooph/humus-amqp-producer/issues/12 and https://github.com/prooph/humus-amqp-producer/issues/13
also fixes https://github.com/prooph/humus-amqp-producer/issues/15 (for v2 branch)

AmqpQueryProducer was 100% completely broken! This is now fixed and tests are added. I'll backport this change to 1.x series, once this is merged.